### PR TITLE
Local file detection and multiple environments with different domains

### DIFF
--- a/includes/class-dlm-download-handler.php
+++ b/includes/class-dlm-download-handler.php
@@ -431,6 +431,12 @@ class DLM_Download_Handler {
 		// Parse file path
 		list( $file_path, $remote_file ) = $file_manager->parse_file_path( $file_path );
 
+		// Check file exists
+		if (empty($file_path)) {
+			$this->log( 'download', 'failed', __( 'File not found.', 'download-monitor' ), $download, $version );
+			wp_die( __( 'File not found.', 'download-monitor' ) . ' <a href="' . home_url() . '">' . __( 'Go to homepage &rarr;', 'download-monitor' ) . '</a>', __( 'Download Error', 'download-monitor' ), array( 'response' => 404 ) );
+		}
+
 		$this->download_headers( $file_path, $download, $version, $remote_file );
 
 		if ( get_option( 'dlm_xsendfile_enabled' ) ) {

--- a/includes/class-dlm-download-handler.php
+++ b/includes/class-dlm-download-handler.php
@@ -431,7 +431,7 @@ class DLM_Download_Handler {
 		// Parse file path
 		list( $file_path, $remote_file ) = $file_manager->parse_file_path( $file_path );
 
-		$this->download_headers( $file_path, $download, $version );
+		$this->download_headers( $file_path, $download, $version, $remote_file );
 
 		if ( get_option( 'dlm_xsendfile_enabled' ) ) {
 			if ( function_exists( 'apache_get_modules' ) && in_array( 'mod_xsendfile', apache_get_modules() ) ) {
@@ -505,7 +505,7 @@ class DLM_Download_Handler {
 	/**
 	 * Output download headers
 	 */
-	private function download_headers( $file_path, $download, $version ) {
+	private function download_headers( $file_path, $download, $version, $remote_file = true ) {
 		global $is_IE;
 
 		// Get Mime Type
@@ -569,8 +569,11 @@ class DLM_Download_Handler {
 		$headers['Content-Disposition']       = "attachment; filename=\"{$file_name}\";";
 		$headers['Content-Transfer-Encoding'] = 'binary';
 
-		if ( $version->filesize ) {
+		if ( $version->filesize >= 0 ) {
 			$headers['Content-Length'] = $version->filesize;
+			$headers['Accept-Ranges']  = 'bytes';
+		} elseif (!$remote_file) {
+			$headers['Content-Length'] = filesize($file_path);
 			$headers['Accept-Ranges']  = 'bytes';
 		}
 

--- a/includes/class-dlm-file-manager.php
+++ b/includes/class-dlm-file-manager.php
@@ -52,6 +52,8 @@ class DLM_File_Manager {
 		$wp_uploads     = wp_upload_dir();
 		$wp_uploads_dir = $wp_uploads['basedir'];
 		$wp_uploads_url = $wp_uploads['baseurl'];
+		$parsed_wp_uploads_url = parse_url( $wp_uploads_url );
+		$dlm_uploads_path = $parsed_wp_uploads_url['path'] . '/dlm_uploads';
 
 		if ( ( ! isset( $parsed_file_path['scheme'] ) || ! in_array( $parsed_file_path['scheme'], array(
 					'http',
@@ -87,6 +89,13 @@ class DLM_File_Manager {
 			$remote_file = false;
 			$file_path   = str_replace( site_url( '/', 'https' ), ABSPATH, $file_path );
 			$file_path   = str_replace( site_url( '/', 'http' ), ABSPATH, $file_path );
+			$file_path   = realpath( $file_path );
+
+		} elseif (isset($parsed_file_path['scheme']) && strncmp($dlm_uploads_path, $parsed_file_path['path'], strlen($dlm_uploads_path)) === 0) {
+
+			/** This is a file with other enviroments domain, just assume it's local */
+			$remote_file = false;
+			$file_path   = ABSPATH . $parsed_file_path['path'];
 			$file_path   = realpath( $file_path );
 
 		} elseif ( file_exists( ABSPATH . $file_path ) ) {


### PR DESCRIPTION
Hi,

Local file detection seems to be annoying and it saves full urls and then tries to figure is it remote or local in parse_file_path. Think the situation where you have production, staging and development environments with own domains.

www.company.tld - Production
company.staging.internal - Staging
company.dev.internal - Development

Now fetch data from production and test it.. download manager seems to fail. Oh, it tries to load the files from production environment but those direct urls are protected and it can't, so it fails.

This patch fixes that situation by just checking that the path starts with dlm path, if the url has schema.

Also this fixes sending Content-Lenght: -1, which makes browsers wait just too long for the content.
