### PR TITLE
Make the newly-visible downloads in search results actually take the visitor to the download.

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -13,3 +13,53 @@ function dlm_get_default_download_template() {
 
 	return $default;
 }
+
+// Filter the single_template with our custom function
+function dlm_download_single_post_type_template($single) {
+	global $wp_query, $post;
+	/* Checks for single template by post type */
+	if ($post->post_type == 'dlm_download' || $post->post_type == 'dlm_download_version'){
+		$download_id = get_the_id();
+		/** @var DLM_Download $download */
+		$download = null;
+
+		if ( $download_id > 0 ) {
+			$download = download_monitor()->service( 'download_repository' )->retrieve_single( $download_id );
+		}
+
+		// Handle version (if set)
+		$version_id = '';
+
+		if ( ! empty( $_GET['version'] ) ) {
+			$version_id = $download->get_version_id_version_name( $_GET['version'] );
+		}
+
+		if ( ! empty( $_GET['v'] ) ) {
+			$version_id = absint( $_GET['v'] );
+		}
+
+		if ( $version_id ) {
+			try {
+				$version = download_monitor()->service( 'version_repository' )->retrieve_single( $version_id );
+				$download->set_version( $version );
+			} catch ( Exception $e ) {
+
+			}
+		}
+
+		// Action on found download
+		if ( ! is_null( $download ) && $download->exists() ) {
+			if ( post_password_required( $download_id ) ) {
+				wp_die( get_the_password_form( $download_id ), __( 'Password Required', 'download-monitor' ) );
+			}
+			$downloadURL = $download->get_the_download_link();
+			wp_redirect($downloadURL);
+		} elseif ( $redirect = apply_filters( 'dlm_404_redirect', false ) ) {
+			wp_redirect( $redirect );
+		} else {
+			wp_die( __( 'Download does not exist.', 'download-monitor' ) . ' <a href="' . home_url() . '">' . __( 'Go to homepage &rarr;', 'download-monitor' ) . '</a>', __( 'Download Error', 'download-monitor' ), array( 'response' => 404 ) );
+		}
+	}
+	return $single;
+}
+add_filter('single_template', 'dlm_download_single_post_type_template');

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -54,8 +54,10 @@ function dlm_download_single_post_type_template($single) {
 			}
 			$downloadURL = $download->get_the_download_link();
 			wp_redirect($downloadURL);
+			exit();
 		} elseif ( $redirect = apply_filters( 'dlm_404_redirect', false ) ) {
 			wp_redirect( $redirect );
+			exit();
 		} else {
 			wp_die( __( 'Download does not exist.', 'download-monitor' ) . ' <a href="' . home_url() . '">' . __( 'Go to homepage &rarr;', 'download-monitor' ) . '</a>', __( 'Download Error', 'download-monitor' ), array( 'response' => 404 ) );
 		}

--- a/src/PostTypeManager.php
+++ b/src/PostTypeManager.php
@@ -14,6 +14,22 @@ class DLM_Post_Type_Manager {
 	 */
 	public function register() {
 
+		// Pull the setting for determining exclude_from_search value
+		if ( 1 == absint( get_option( 'dlm_wp_search_enabled', 0 ) ) ) { // They have chosen to make downloads show in WordPress search as well as being linked to directly
+			$exclude_from_search = false;
+			$publicly_visible = true;
+		} else { // Default to not having downloads included in search & accessible
+			$exclude_from_search = true;
+			$publicly_visible = false;
+		}
+
+		// Check the Download Monitor setting/option for its download endpoint/URL/slug
+		if(get_option('dlm_download_endpoint_value') == 'slug'){
+			$rewrite = array( 'slug' => get_option('dlm_download_endpoint').'-link'); // Append "-link" to slug to prevent conflict with the existing slug handling (would cause redirect loop if this matched exactly)
+		}else{
+			$rewrite = false;
+		}
+
 		// Register Download Post Type
 		register_post_type( "dlm_download",
 			apply_filters( 'dlm_cpt_dlm_download_args', array(
@@ -34,7 +50,7 @@ class DLM_Post_Type_Manager {
 					'parent'             => __( 'Parent Download', 'download-monitor' )
 				),
 				'description'         => __( 'This is where you can create and manage downloads for your site.', 'download-monitor' ),
-				'public'              => false,
+				'public'              => $publicly_visible,
 				'show_ui'             => true,
 				'capability_type'     => 'post',
 				'capabilities'        => array(
@@ -48,11 +64,11 @@ class DLM_Post_Type_Manager {
 					'delete_post'         => 'manage_downloads',
 					'read_post'           => 'manage_downloads'
 				),
-				'publicly_queryable'  => false,
-				'exclude_from_search' => ( 1 !== absint( get_option( 'dlm_wp_search_enabled', 0 ) ) ),
+				'publicly_queryable'  => $publicly_visible,
+				'exclude_from_search' => $exclude_from_search,
 				'hierarchical'        => false,
-				'rewrite'             => false,
-				'query_var'           => false,
+				'rewrite'             => $rewrite,
+				'query_var'           => $publicly_visible,
 				'supports'            => apply_filters( 'dlm_cpt_dlm_download_supports', array(
 					'title',
 					'editor',
@@ -84,13 +100,13 @@ class DLM_Post_Type_Manager {
 					'not_found_in_trash' => __( 'No Download Versions found in trash', 'download-monitor' ),
 					'parent'             => __( 'Parent Download Version', 'download-monitor' )
 				),
-				'public'              => false,
+				'public'              => $publicly_visible,
 				'show_ui'             => false,
-				'publicly_queryable'  => false,
+				'publicly_queryable'  => $publicly_visible,
 				'exclude_from_search' => true,
 				'hierarchical'        => false,
 				'rewrite'             => false,
-				'query_var'           => false,
+				'query_var'           => $publicly_visible,
 				'show_in_nav_menus'   => false
 			) )
 		);


### PR DESCRIPTION
The 4.0.0 update implemented the option for enabling search visibility, but then Algolia surfaces the permalinks for the downloads which are then not able to be viewed due to the previous other settings & setup in 4.0.0.

This update makes it so the permalinks surfaced via search take the visitor to the download if the site has had searchable downloads enabled (otherwise, everything is left untouched).