### PR TITLE
Pass $size to dlm_placeholder_image_src filter

### DIFF
--- a/src/Download/Download.php
+++ b/src/Download/Download.php
@@ -296,7 +296,7 @@ class DLM_Download {
 		if ( has_post_thumbnail( $this->id ) ) {
 			return get_the_post_thumbnail( $this->id, $size );
 		} else {
-			return '<img alt="Placeholder" class="wp-post-image" src="' . apply_filters( 'dlm_placeholder_image_src', download_monitor()->get_plugin_url() . '/assets/images/placeholder.png', $this->id, $this ) . '" />';
+			return '<img alt="Placeholder" class="wp-post-image" src="' . apply_filters( 'dlm_placeholder_image_src', download_monitor()->get_plugin_url() . '/assets/images/placeholder.png', $this->id, $this, $size ) . '" />';
 		}
 	}
 


### PR DESCRIPTION
If someone is requesting a different size image it would be good to try to respect
their wishes with a properly sized placeholder (if available).

In my use case I just hard code the size, but I could see potential use cases in templates where you potentially want a different size.