### PR TITLE
Pass version data to the interface hooks.

### DIFF
--- a/assets/views/meta-box/version.php
+++ b/assets/views/meta-box/version.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<table cellpadding="0" cellspacing="0" class="dlm-metabox-content">
 		<tbody>
 
-		<?php do_action( 'dlm_downloadable_file_version_table_start' ); ?>
+		<?php do_action( 'dlm_downloadable_file_version_table_start', $file_id, $version ); ?>
 
 		<tr>
 			<td width="1%">
@@ -115,7 +115,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 
 
-		<?php do_action( 'dlm_downloadable_file_version_table_end' ); ?>
+		<?php do_action( 'dlm_downloadable_file_version_table_end', $file_id, $version ); ?>
 
 		</tbody>
 	</table>


### PR DESCRIPTION
Context: wanted to add additional data to each version in the admin interface.

The hooks exist, but without passing any data it can be difficult to determine the current version you're outputting when hooking in.

The data passed is based on the actions found within [other dlm metaboxes](https://github.com/download-monitor/download-monitor/blob/master/src/Admin/WritePanels.php#L122-L142).

Thanks!