### PR TITLE
Make `featured` in `[downloads]` unrequired

### DIFF
--- a/src/Shortcodes.php
+++ b/src/Shortcodes.php
@@ -416,12 +416,6 @@ class DLM_Shortcodes {
 				'key'   => '_featured',
 				'value' => 'yes'
 			);
-		} else {
-			$args['meta_query'][] = array(
-				'key'     => '_featured',
-				'value'   => 'yes',
-				'compare' => '!='
-			);
 		}
 
 		if ( $members_only === 'true' || $members_only === true ) {


### PR DESCRIPTION
Hi,

This doesn't exclude when `featured` is not set: 
```php
 $args['meta_query'][] = array(
 	'key'     => '_featured',
 	'value'   => 'yes',
 	'compare' => '!='
 );
```

Removing this part altogether like in my commit is equal to having:
```php
$args['meta_query'][] = array(
	'relation' => 'OR',
	array(
		'key'     => '_featured',
		'value'   => 'yes',
		'compare' => '!='
	),
	array(
		'key'     => '_featured',
		'compare' => 'NOT EXISTS'
	),
);

```