### PR TITLE
Remove default values for required parameters #682

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -10,15 +10,15 @@
  *
  * @deprecated 1.6.0
  *
- * @param string $type (default: '')
- * @param string $status (default: '')
- * @param string $message (default: '')
+ * @param string $type
+ * @param string $status
+ * @param string $message
  * @param mixed $download
  * @param mixed $version
  *
  * @return void
  */
-function dlm_create_log( $type = '', $status = '', $message = '', $download, $version ) {
+function dlm_create_log( $type, $status, $message, $download, $version ) {
 
 	// Deprecated notice
 	_deprecated_function( __FUNCTION__, '1.6.0', 'DLM_Logging->create_log()' );

--- a/src/DownloadHandler.php
+++ b/src/DownloadHandler.php
@@ -333,7 +333,7 @@ class DLM_Download_Handler {
 	 * @param DLM_Download $download
 	 * @param DLM_Download_Version $version
 	 */
-	private function log( $type = '', $status = '', $message = '', $download, $version ) {
+	private function log( $type, $status, $message, $download, $version ) {
 
 		// Logging object
 		$logging = new DLM_Logging();


### PR DESCRIPTION
Closes #682 

Removes default values for required parameters. (The latter parameters do not have default values, which then ends up making the earlier ones required anyway.)

This fixes deprecation notices in PHP 8.