### PR TITLE
Add support for network drive file paths

### DIFF
--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -95,7 +95,25 @@ class DLM_File_Manager {
 				$file_path = realpath( $file_path );
 			}
 
-		} elseif ( strpos( $file_path, $wp_uploads_url ) !== false ) {
+		} elseif ( strpos( $wp_uploads_dir, '://' ) !== false ) {
+
+			/** 
+			 * This is a file located on a network drive.  
+			 * WordPress VIP is a providor that uses network drive paths
+			 * Only allow if root (vip://) is predefined in Settings > Misc > Other downloads path
+			 * Example of path: vip://wp-content/upload...
+			 **/
+			$remote_file = false;
+			$path = array_reduce( $allowed_paths, function ($carry, $path) use ($wp_uploads_dir, $wp_uploads_url, $file_path ) {
+				return strpos( $path, '://' ) !== false && strpos( $wp_uploads_dir, $path ) !== false 
+					? trim( str_replace( $wp_uploads_url, $wp_uploads_dir, $file_path ) )
+					: $carry;
+			}, false);
+
+			// realpath() will return false on network drive paths, so just check if exists
+			$file_path = file_exists( $path ) ? $path : realpath( $file_path );
+
+		}  elseif ( strpos( $file_path, $wp_uploads_url ) !== false ) {
 
 			/** This is a local file given by URL, so we need to figure out the path */
 			$remote_file = false;


### PR DESCRIPTION
WordPress VIP uses network drives for their content.  Currently there is no logic that can handle this and just attempts a realpath(), which will return false.

Case:
vip://wp-content/wp-upload...

Solution:

1) Admin can add the network drive root (vip://) to Settings > Misc > Other Download folder (allowed paths)
2) Add case in parse_url_path() to check if base directory includes a network path.
3) Verify if network drive has been added to allowed paths and clean url and validate the file exists, 

Return validate and approved path.

Tested on WordPress VIP servers


