### PR TITLE
5.0.7 update

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-= 5.0.7 - 26.08.2024 =
+= 5.0.7 - 27.08.2024 =
 Fixed: Versions order not following menu order ( [#1511](https://github.com/WPChill/download-monitor/issues/1511) )
 Fixed: Undefined variable ( [#1523](https://github.com/WPChill/download-monitor/issues/1523) )
 Fixed: Not logging downloads in some conditions ( [#1522](https://github.com/WPChill/download-monitor/issues/1522) )

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+= 5.0.7 - 26.08.2024 =
+Fixed: Versions order not following menu order ( [#1511](https://github.com/WPChill/download-monitor/issues/1511) )
+Fixed: Undefined variable ( [#1523](https://github.com/WPChill/download-monitor/issues/1523) )
+Fixed: Not logging downloads in some conditions ( [#1522](https://github.com/WPChill/download-monitor/issues/1522) )
+
 = 5.0.5 - 22.08.2024 =
 Fixed: Dev bugfixes
 

--- a/download-monitor.php
+++ b/download-monitor.php
@@ -3,7 +3,7 @@
 	Plugin Name: Download Monitor
 	Plugin URI: https://www.download-monitor.com
 	Description: A full solution for managing and selling downloadable files, monitoring downloads and outputting download links and file information on your WordPress powered site.
-	Version: 5.0.6
+	Version: 5.0.7
 	Author: WPChill
 	Author URI: https://wpchill.com
 	Requires at least: 5.5
@@ -34,7 +34,7 @@ if (! defined('ABSPATH')) {
 } // Exit if accessed directly
 
 // Define DLM Version
-define('DLM_VERSION', '5.0.6');
+define('DLM_VERSION', '5.0.7');
 define('DLM_UPGRADER_VERSION', '4.6.0');
 
 // Define DLM FILE

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "download-monitor",
   "title": "Download Monitor",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "homepage": "https://www.download-monitor.com",
   "main": "Gruntfile.js",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -128,7 +128,7 @@ Admin hits are not counted, log out and try again!
 
 == Changelog ==
 
-= 5.0.7 - 26.08.2024 =
+= 5.0.7 - 27.08.2024 =
 Fixed: Versions order not following menu order ( [#1511](https://github.com/WPChill/download-monitor/issues/1511) )
 Fixed: Undefined variable ( [#1523](https://github.com/WPChill/download-monitor/issues/1523) )
 Fixed: Not logging downloads in some conditions ( [#1522](https://github.com/WPChill/download-monitor/issues/1522) )

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wpchill, silkalns, barrykooij, mikejolley
 Tags: download manager, file manager, digital store, ecommerce, password protection
 Requires at least: 5.5
 Tested up to: 6.6
-Stable tag: 5.0.6
+Stable tag: 5.0.7
 License: GPLv3
 Requires PHP: 7.6
 
@@ -127,6 +127,11 @@ Admin hits are not counted, log out and try again!
 4. The quick add panel can be opened via a link about the post editor. This lets you quickly add a file and insert it into a post.
 
 == Changelog ==
+
+= 5.0.7 - 26.08.2024 =
+Fixed: Versions order not following menu order ( [#1511](https://github.com/WPChill/download-monitor/issues/1511) )
+Fixed: Undefined variable ( [#1523](https://github.com/WPChill/download-monitor/issues/1523) )
+Fixed: Not logging downloads in some conditions ( [#1522](https://github.com/WPChill/download-monitor/issues/1522) )
 
 = 5.0.5 - 23.08.2024 =
 Fixed: Dev fixes

--- a/src/Logs/WordPressLogItemRepository.php
+++ b/src/Logs/WordPressLogItemRepository.php
@@ -139,6 +139,11 @@ class DLM_WordPress_Log_Item_Repository implements DLM_Log_Item_Repository {
 		}
 
 		$logging = DLM_Logging::get_instance();
+		global $wpdb;
+		$download_id = $log_item->get_download_id();
+		$version_id  = $log_item->get_version_id();
+		$version     = download_monitor()->service( 'version_manager' )->get_version( $version_id );
+		$url         = $log_item->get_current_url();
 		// Don't count if only unique IPs are counted and the IP has already downloaded the version.
 		if ( $logging->is_count_unique_ips_only() && true === $logging->has_uuid_downloaded_version( $version ) ) {
 			return;
@@ -148,9 +153,6 @@ class DLM_WordPress_Log_Item_Repository implements DLM_Log_Item_Repository {
 			return;
 		}
 
-		global $wpdb;
-		$download_id = $log_item->get_download_id();
-		$version_id  = $log_item->get_version_id();
 		// allow filtering of log item.
 		$log_item = apply_filters( 'dlm_log_item', $log_item, $download_id, $version_id );
 

--- a/src/Version/WordPressVersionRepository.php
+++ b/src/Version/WordPressVersionRepository.php
@@ -116,11 +116,8 @@ class DLM_WordPress_Version_Repository implements DLM_Version_Repository {
 	 * @return array<DLM_Download>
 	 */
 	public function retrieve( $filters = array(), $limit = 0, $offset = 0 ) {
-
 		$items = array();
-
-		$q     = new WP_Query();
-		$posts = $q->query( $this->filter_query_args( $filters, $limit, $offset ) );
+		$posts = get_posts( $this->filter_query_args( $filters, $limit, $offset ) );
 
 		if ( count( $posts ) > 0 ) {
 


### PR DESCRIPTION
Fixed: Versions order not following menu order ( [#1511](https://github.com/WPChill/download-monitor/issues/1511) )
Fixed: Undefined variable ( [#1523](https://github.com/WPChill/download-monitor/issues/1523) )
Fixed: Not logging downloads in some conditions ( [#1522](https://github.com/WPChill/download-monitor/issues/1522) )