### PR TITLE
Use $upload_path instead of construction the upload path: Update clas…

### DIFF
--- a/src/Admin/DownloadPaths/class-dlm-downloads-path.php
+++ b/src/Admin/DownloadPaths/class-dlm-downloads-path.php
@@ -103,7 +103,9 @@ class DLM_Downloads_Path {
 			register_setting( 'dlm_advanced_download_path', 'dlm_network_settings', $multi_args );
 
 			$site_id = get_current_blog_id();
-			$uploads = WP_CONTENT_DIR . '/uploads/sites/' . $site_id;
+			// $uploads = WP_CONTENT_DIR . '/uploads/sites/' . $site_id;
+                        $uploads = $upload_path;
+
 			if ( ! empty( $_GET['id'] ) && ! empty( $_GET['page'] ) && 'download-monitor-paths' === $_GET['page'] ) {
 				$site_id = absint( $_GET['id'] );
 				// Create the uploads path for the site.


### PR DESCRIPTION
…s-dlm-downloads-path.php

The upload Path is constructed in this line

$uploads = WP_CONTENT_DIR . '/uploads/sites/' . $site_id;

But the upload path can vary in different installations. 

Maybe it's easier to use the predefined variable $upload_path

See also https://developer.wordpress.org/reference/functions/wp_upload_dir/ 

Since I made that change, my downloads are working agaiin.