### PR TITLE
Only set session on no-access-page visit instead of every page visit. 

### DIFF
--- a/src/DLM.php
+++ b/src/DLM.php
@@ -980,7 +980,7 @@ class WP_DLM {
 	public function set_no_access_session() {
 		$no_access_page = get_option( 'dlm_no_access_page', 0 );
 		$set_session    = $no_access_page && ( is_page( $no_access_page ) || is_single( $no_access_page ) );
-		$set_session    = apply_filters( 'dlm_set_no_access_session', $set_session );
+		$set_session    = apply_filters( 'dlm_set_no_access_session', $set_session, $no_access_page );
 		if ( $set_session && ! isset( $_SESSION ) ) {
 			$is_https = ( ! empty( $_SERVER['HTTPS'] ) && 'off' !== $_SERVER['HTTPS'] ) || ( isset( $_SERVER['SERVER_PORT'] ) && 443 === $_SERVER['SERVER_PORT'] );
 			$params   = array(

--- a/src/DLM.php
+++ b/src/DLM.php
@@ -979,7 +979,8 @@ class WP_DLM {
 	 */
 	public function set_no_access_session() {
 		$no_access_page = get_option( 'dlm_no_access_page', 0 );
-		if ( apply_filters( 'dlm_set_no_access_session', $no_access_page ) && ! isset( $_SESSION ) ) {
+		$no_access_page = apply_filters( 'dlm_set_no_access_session', $no_access_page );
+		if ( $no_access_page && ! isset( $_SESSION ) && ( is_page( $no_access_page ) || is_single( $no_access_page ) ) ) {
 			$is_https = ( ! empty( $_SERVER['HTTPS'] ) && 'off' !== $_SERVER['HTTPS'] ) || ( isset( $_SERVER['SERVER_PORT'] ) && 443 === $_SERVER['SERVER_PORT'] );
 			$params   = array(
 				'secure'   => $is_https,

--- a/src/DLM.php
+++ b/src/DLM.php
@@ -979,8 +979,9 @@ class WP_DLM {
 	 */
 	public function set_no_access_session() {
 		$no_access_page = get_option( 'dlm_no_access_page', 0 );
-		$no_access_page = apply_filters( 'dlm_set_no_access_session', $no_access_page );
-		if ( $no_access_page && ! isset( $_SESSION ) && ( is_page( $no_access_page ) || is_single( $no_access_page ) ) ) {
+		$set_session    = $no_access_page && ( is_page( $no_access_page ) || is_single( $no_access_page ) );
+		$set_session    = apply_filters( 'dlm_set_no_access_session', $set_session );
+		if ( $set_session && ! isset( $_SESSION ) ) {
 			$is_https = ( ! empty( $_SERVER['HTTPS'] ) && 'off' !== $_SERVER['HTTPS'] ) || ( isset( $_SERVER['SERVER_PORT'] ) && 443 === $_SERVER['SERVER_PORT'] );
 			$params   = array(
 				'secure'   => $is_https,


### PR DESCRIPTION
Some time ago I've contacted Download monitor (via support@download-monitor.com) to report an issue regarding creating a session when the the no-access-page is set.
For reference, the issue number is #24075.

This PR will make a suggestion to fix the issue as described in the original ticket, and described again below.

## Original ticket contents (the problem)

Dear Download Monitor Employee,

Since Download Monitor version 5.0.14 a fix has been implemented to fix session performance problems (see changelog).
This fix calls the `WP_DLM::set_no_access_session()` function on the `wp` hook.
And that function starts a PHP session, if a no-access-page has been set (this is set by default on install of the plugin.
This `session_start()` happens now on every pageload.

This is a problem when using Nginx, because having a PHP session will also by default result in disabling fastcgi microcache (and by the way also other caching methods).
And because this code runs on every pageload, this will result in the whole website not being cached.
And as you can imagine, this would hurt the performance websites a lot.
The solution should be to only start a new session if the actual no-access-page is being visited.
The modified code should look something like this:

/**
 * Set no access session
 *
 * @return void
 * @since 5.0.14
 */
public function set_no_access_session() {
    $no_access_page = get_option( 'dlm_no_access_page', 0 );
    if ( $no_access_page && ! isset( $_SESSION ) && is_page( $no_access_page ) ) {
        session_start();
    }
}
```

I hope that you will be able to implement the change in one of the upcoming versions.
If there are any questions remaining, please feel free to ask them. I'll be happy to help.

Kind regards,

Menno van den Ende

## The suggested solution (this PR code)

The proposed change will allow caching to work on all pages of the website again, except for the no-access-page of Download Monitor.

In this PR the following modifications have been made:
1. Add additional check if the current page is the no_access_page 
2. Modify the behavior of the `dlm_set_no_access_session` filter, to
  - Actually filter the determination if the no_access_session should be started
  - Return a bool instead of an int
  - Get passed the no-access-page ID as a parameter