### PR TITLE
Release 5.1.2 - Fixed session handling to start only on download-related requests.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+= 5.1.2 - 05.09.2025 =
+Fixed: Start session only on download-related requests.
+
 = 5.1.1 - 01.09.2025 =
 Fixed: Removed stray debugger statements.
 

--- a/download-monitor.php
+++ b/download-monitor.php
@@ -3,7 +3,7 @@
 	Plugin Name: Download Monitor
 	Plugin URI: https://www.download-monitor.com
 	Description: A full solution for managing and selling downloadable files, monitoring downloads and outputting download links and file information on your WordPress powered site.
-	Version: 5.1.1
+	Version: 5.1.2
 	Author: WPChill
 	Author URI: https://wpchill.com
 	Requires at least: 6.4
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 } // Exit if accessed directly
 
 // Define DLM Version
-define('DLM_VERSION', '5.1.1');
+define('DLM_VERSION', '5.1.2');
 define('DLM_UPGRADER_VERSION', '4.6.0');
 
 // Define DLM FILE

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "download-monitor",
   "title": "Download Monitor",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "homepage": "https://www.download-monitor.com",
   "main": "Gruntfile.js",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wpchill, silkalns, barrykooij, mikejolley
 Tags: download manager, file manager, digital store, ecommerce, password protection  
 Requires at least: 5.5  
 Tested up to: 6.8  
-Stable tag: 5.1.1
+Stable tag: 5.1.2
 License: GPLv3  
 Requires PHP: 7.6  
 
@@ -114,6 +114,10 @@ Admin hits are not counted, log out and try again!
 4. The quick add panel can be opened via a link about the post editor. This lets you quickly add a file and insert it into a post.
 
 == Changelog ==
+
+= 5.1.2 - 05.09.2025 =
+Fixed: Start session only on download-related requests.
+
 = 5.1.1 - 01.09.2025 =
 Fixed: Removed stray debugger statements.
 


### PR DESCRIPTION
Related to #1672